### PR TITLE
Detect format from byte array

### DIFF
--- a/src/FrontEnd/Library/BinHandlerHelper.fs
+++ b/src/FrontEnd/Library/BinHandlerHelper.fs
@@ -50,11 +50,14 @@ let initHelpers isa =
 
 let newFileInfo bytes (baseAddr: Addr) path isa autoDetect =
   if autoDetect then
-    match FormatDetector.detect path with
-    | FileFormat.ELFBinary -> new ELFFileInfo (bytes, path) :> FileInfo
-    | FileFormat.PEBinary -> new PEFileInfo (bytes, path) :> FileInfo
-    | FileFormat.MachBinary -> new MachFileInfo (bytes, path, isa) :> FileInfo
-    | _ -> new RawFileInfo (bytes, baseAddr, isa) :> FileInfo
+    if System.IO.File.Exists path
+    then FormatDetector.detect path
+    else FormatDetector.detectBuffer bytes
+    |> function
+      | FileFormat.ELFBinary -> new ELFFileInfo (bytes, path) :> FileInfo
+      | FileFormat.PEBinary -> new PEFileInfo (bytes, path) :> FileInfo
+      | FileFormat.MachBinary -> new MachFileInfo (bytes, path, isa) :> FileInfo
+      | _ -> new RawFileInfo (bytes, baseAddr, isa) :> FileInfo
   else new RawFileInfo (bytes, baseAddr, isa) :> FileInfo
 
 let detectThumb entryPoint (isa: ISA) =


### PR DESCRIPTION
The new ``autoDetect`` argument in ``BinHandler.Init`` function doesn't consider detection on an array of bytes.

This PR slightly modify the code in order to consider also the detection given an array of bytes.