### PR TITLE
[BinFile] Added boundary check on file format detector

### DIFF
--- a/src/BinFile/ELFHeader.fs
+++ b/src/BinFile/ELFHeader.fs
@@ -33,6 +33,7 @@ let private elfMagicNumber = [| 0x7fuy; 0x45uy; 0x4cuy; 0x46uy |]
 
 /// Check if the file has a valid ELF header.
 let isELF (reader: BinReader) offset =
+  reader.Length() > offset + sizeof<uint32> &&
   reader.PeekBytes (4, offset) = elfMagicNumber
 
 let peekClass (reader: BinReader) offset =

--- a/src/BinFile/MachHeader.fs
+++ b/src/BinFile/MachHeader.fs
@@ -30,7 +30,10 @@ open B2R2
 open B2R2.BinFile
 
 let peekMagic (reader: BinReader) offset =
-  reader.PeekUInt32 offset |> LanguagePrimitives.EnumOfValue
+  if reader.Length() > offset + sizeof<uint32>
+  then reader.PeekUInt32 offset
+  else 0ul
+  |> LanguagePrimitives.EnumOfValue
 
 let isFat reader offset =
   match peekMagic reader offset with


### PR DESCRIPTION
Some missing boundary checks cause an unhandled exception during a file format detection process.

The bug is triggered when a new Binary handler is created, with auto detection enabled, on a very small buffer.