### PR TITLE
[BinFile] parsing ImportAddressTableRVA when ImportLookupTableRVA is 0

### DIFF
--- a/src/BinFile/PEHelper.fs
+++ b/src/BinFile/PEHelper.fs
@@ -104,7 +104,8 @@ let parseILT binReader headers wordSize map idt =
       let entry = parseILTEntry binReader headers idt mask rva
       let map = Map.add (idt.ImportAddressTableRVA + rvaOffset) entry map
       loop map (rvaOffset + skip) (pos + skip)
-  idt.ImportLookupTableRVA
+  if idt.ImportLookupTableRVA <> 0 then idt.ImportLookupTableRVA
+  else idt.ImportAddressTableRVA
   |> getRawOffset headers
   |> loop map 0
 


### PR DESCRIPTION
Some packers set ``ImportLookupTableRVA`` to NULL in order to avoid to be easily analyzed (like VMProtect). According to MS documentation ([1]) the content of ``ImportAddressTableRVA`` is exactly the same of ``ImportLookupTableRVA`` before the file is bounded in memory.

This PR consider the parsing of ``ImportAddressTableRVA`` if the value of ``ImportLookupTableRVA`` is NULL.

Ref.
[1] - https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format#import-directory-table