### PR TITLE
[BinFile] Implemented parsing relocation table in PE file

### DIFF
--- a/src/BinFile/PE.fs
+++ b/src/BinFile/PE.fs
@@ -106,8 +106,9 @@ type PEFileInfo (bytes, path, ?rawpdb) =
 
   override __.GetRelocationSymbols () =
     pe.RelocBlocks
-    |> Seq.collect(fun block -> block.Entries |> Seq.map(fun entry -> (block, entry)))
-    |> Seq.map(fun (block, entry) -> {
+    |> Seq.collect (fun block ->
+      block.Entries |> Seq.map(fun entry -> (block, entry)))
+    |> Seq.map (fun (block, entry) -> {
       Address = uint64 (block.PageRVA + uint32 entry.Offset)
       Name = String.Empty
       Kind = SymbolKind.NoType

--- a/src/BinFile/PEHelper.fs
+++ b/src/BinFile/PEHelper.fs
@@ -193,7 +193,6 @@ let parseExports binReader (headers: PEHeaders) =
 let buildRelocBlock (binReader: BinReader) headerOffset =  
   let blockSize = binReader.PeekInt32 (headerOffset + 4)
   let upperBound = headerOffset + blockSize
-
   let rec parseBlock offset entries =
     if offset < upperBound then
       let buffer = binReader.PeekUInt16(offset)
@@ -202,7 +201,6 @@ let buildRelocBlock (binReader: BinReader) headerOffset =
       |> parseBlock (offset + 2)
     else
       entries |> List.toArray
-
   { PageRVA = binReader.PeekUInt32 headerOffset
     BlockSize = blockSize
     Entries = parseBlock (headerOffset + 8) List.empty }
@@ -213,7 +211,6 @@ let parseRelocation (binReader: BinReader) (headers: PEHeaders) =
   | rva ->
     let headerOffset = getRawOffset headers rva
     let upperBound = headerOffset + headers.PEHeader.BaseRelocationTableDirectory.Size
-
     let rec parseRelocationDirectory offset blocks =
       if offset < upperBound then
         let relocBlock = buildRelocBlock binReader offset

--- a/src/BinFile/PETypes.fs
+++ b/src/BinFile/PETypes.fs
@@ -28,6 +28,37 @@ namespace B2R2.BinFile.PE
 
 open B2R2
 open System.Reflection.PortableExecutable
+open System.Reflection.Metadata
+
+/// Base Relocation Type.
+type BaseRelocType =                                                                                              
+  | IMAGE_REL_BASED_ABSOLUTE        = 0
+  | IMAGE_REL_BASED_HIGH            = 1
+  | IMAGE_REL_BASED_LOW             = 2
+  | IMAGE_REL_BASED_HIGHLOW         = 3
+  | IMAGE_REL_BASED_HIGHADJ         = 4
+  | IMAGE_REL_BASED_MIPS_JMPADDR    = 5
+  | IMAGE_REL_BASED_ARM_MOV32       = 5
+  | IMAGE_REL_BASED_RISCV_HIGH20    = 5
+  | Reserved                        = 6
+  | IMAGE_REL_BASED_THUMB_MOV32     = 7
+  | IMAGE_REL_BASED_RISCV_LOW12I    = 7
+  | IMAGE_REL_BASED_RISCV_LOW12S    = 8
+  | IMAGE_REL_BASED_MIPS_JMPADDR16  = 9
+  | IMAGE_REL_BASED_DIR64           = 10
+
+/// Relocation Block Entry.
+type RelocBlockEntry = {
+  Type: BaseRelocType
+  Offset: uint16
+}
+
+/// Relocation Block
+type RelocBlock = {
+  PageRVA: uint32
+  BlockSize: int32
+  Entries: RelocBlockEntry []
+}
 
 /// The import information begins with the import directory table, which
 /// describes the remainder of the import information. There is one
@@ -218,6 +249,8 @@ type PE = {
   ImportMap: Map<int, ImportInfo>
   /// Address to exported function name.
   ExportMap: Map<Addr, string>
+  /// List of relocation blocks
+  RelocBlocks: RelocBlock list
   /// Word size for the binary.
   WordSize: WordSize
   /// Symbol information from PDB.

--- a/src/BinFile/PETypes.fs
+++ b/src/BinFile/PETypes.fs
@@ -28,24 +28,23 @@ namespace B2R2.BinFile.PE
 
 open B2R2
 open System.Reflection.PortableExecutable
-open System.Reflection.Metadata
 
 /// Base Relocation Type.
 type BaseRelocType =                                                                                              
-  | IMAGE_REL_BASED_ABSOLUTE        = 0
-  | IMAGE_REL_BASED_HIGH            = 1
-  | IMAGE_REL_BASED_LOW             = 2
-  | IMAGE_REL_BASED_HIGHLOW         = 3
-  | IMAGE_REL_BASED_HIGHADJ         = 4
-  | IMAGE_REL_BASED_MIPS_JMPADDR    = 5
-  | IMAGE_REL_BASED_ARM_MOV32       = 5
-  | IMAGE_REL_BASED_RISCV_HIGH20    = 5
-  | Reserved                        = 6
-  | IMAGE_REL_BASED_THUMB_MOV32     = 7
-  | IMAGE_REL_BASED_RISCV_LOW12I    = 7
-  | IMAGE_REL_BASED_RISCV_LOW12S    = 8
-  | IMAGE_REL_BASED_MIPS_JMPADDR16  = 9
-  | IMAGE_REL_BASED_DIR64           = 10
+  | ImageRelBasedAbsolute = 0
+  | ImageRelBasedHigh = 1
+  | ImageRelBasedLow = 2
+  | ImageRelBasedHighlow = 3
+  | ImageRelBasedHighadj = 4
+  | ImageRelBasedMipsJmpaddr = 5
+  | ImageRelBasedArmMov32 = 5
+  | ImageRelBasedRiscvHigh20 = 5
+  | Reserved = 6
+  | ImageRelBasedThumbMov32 = 7
+  | ImageRelBasedRiscvLow12I =  7
+  | ImageRelBasedRiscvLow12S = 8
+  | ImageRelBasedMipsJmpaddr16 = 9
+  | ImageRelBasedDir64 = 10
 
 /// Relocation Block Entry.
 type RelocBlockEntry = {


### PR DESCRIPTION
I implemented the parsing of the relocation table for PE file.

I left default values when a symbol is created in ``GetRelocationSymbols``, since I'm not sure what the values should be.