### PR TITLE
[BinFile] Add 'BaseAddress' field to FileInfo

### DIFF
--- a/src/BinFile/ELF.fs
+++ b/src/BinFile/ELF.fs
@@ -44,6 +44,7 @@ type ELFFileInfo (bytes, path) =
   override __.IsStripped = not (Map.containsKey ".symtab" elf.SecInfo.SecByName)
   override __.IsNXEnabled = isNXEnabled elf
   override __.IsRelocatable = isRelocatable elf
+  override __.BaseAddress = getBaseAddr elf
   override __.EntryPoint = Some elf.ELFHdr.EntryPoint
   override __.TextStartAddr = getTextStartAddr elf
   override __.TranslateAddress addr = translateAddr addr elf

--- a/src/BinFile/ELFHelper.fs
+++ b/src/BinFile/ELFHelper.fs
@@ -47,6 +47,14 @@ let isRelocatable elf =
   && Section.getDynamicSectionEntries elf.BinReader elf.SecInfo
      |> List.exists pred
 
+let getBaseAddr (elf: ELF) =
+  let lowestPH =
+    elf.ProgHeaders
+    |> List.filter (fun ph -> ph.PHType = ProgramHeaderType.PTLoad)
+    |> List.filter(fun ph -> ph.PHFileSize > 0UL && ph.PHMemSize > 0UL)
+    |> List.minBy (fun ph -> ph.PHAddr)
+  lowestPH.PHAddr
+
 let inline getTextStartAddr elf =
   (Map.find ".text" elf.SecInfo.SecByName).SecAddr
 

--- a/src/BinFile/FileInfo.fs
+++ b/src/BinFile/FileInfo.fs
@@ -76,6 +76,12 @@ type FileInfo () =
   abstract IsRelocatable: bool
 
   /// <summary>
+  ///   The base address of this binary
+  ///   (at which this binary is prefered to be loaded in memory).
+  /// </summary>
+  abstract BaseAddress: Addr
+
+  /// <summary>
   ///   The entry point of this binary (the start address that this binary runs
   ///   at). Note that some binaries (e.g., PE DLL files) do not have a specific
   ///   entry point, and EntryPoint will return None in such a case.

--- a/src/BinFile/Mach.fs
+++ b/src/BinFile/Mach.fs
@@ -44,6 +44,7 @@ type MachFileInfo (bytes, path, isa) =
   override __.IsStripped = isStripped mach
   override __.IsNXEnabled = isNXEnabled mach
   override __.IsRelocatable = mach.MachHdr.Flags.HasFlag MachFlag.MHPIE
+  override __.BaseAddress = getBaseAddr mach
   override __.EntryPoint = mach.EntryPoint
   override __.TextStartAddr = getTextStartAddr mach
   override __.TranslateAddress addr = translateAddr mach addr

--- a/src/BinFile/MachHelper.fs
+++ b/src/BinFile/MachHelper.fs
@@ -76,6 +76,13 @@ let isNXEnabled mach =
   not (mach.MachHdr.Flags.HasFlag MachFlag.MHAllowStackExecution)
   || mach.MachHdr.Flags.HasFlag MachFlag.MHNoHeapExecution
 
+let getBaseAddr (mach: Mach) =
+  let textSegment =
+    mach.Segments
+    |> List.filter (fun seg -> seg.FileOff = 0UL && seg.FileSize > 0UL)
+    |> List.head
+  textSegment.VMAddr
+
 let inline getTextStartAddr mach =
   (Map.find "__text" mach.Sections.SecByName).SecAddr
 

--- a/src/BinFile/MachHelper.fs
+++ b/src/BinFile/MachHelper.fs
@@ -77,11 +77,11 @@ let isNXEnabled mach =
   || mach.MachHdr.Flags.HasFlag MachFlag.MHNoHeapExecution
 
 let getBaseAddr (mach: Mach) =
-  let textSegment =
+  let lowestSegment =
     mach.Segments
-    |> List.filter (fun seg -> seg.FileOff = 0UL && seg.FileSize > 0UL)
-    |> List.head
-  textSegment.VMAddr
+    |> List.filter (fun seg -> seg.FileSize > 0UL)
+    |> List.minBy (fun seg -> seg.VMAddr)
+  lowestSegment.VMAddr
 
 let inline getTextStartAddr mach =
   (Map.find "__text" mach.Sections.SecByName).SecAddr

--- a/src/BinFile/PE.fs
+++ b/src/BinFile/PE.fs
@@ -43,6 +43,7 @@ type PEFileInfo (bytes, path, ?rawpdb) =
   override __.IsStripped = Array.length pe.SymbolInfo.SymbolArray = 0
   override __.IsNXEnabled = isNXEnabled pe
   override __.IsRelocatable = isRelocatable pe
+  override __.BaseAddress = pe.PEHeaders.PEHeader.ImageBase
   override __.EntryPoint = getEntryPoint pe
   override __.TextStartAddr = getTextStartAddr pe
   override __.TranslateAddress addr = translateAddr pe addr

--- a/src/BinFile/RawBinary.fs
+++ b/src/BinFile/RawBinary.fs
@@ -51,6 +51,8 @@ type RawFileInfo (bytes: byte [], baseAddr, isa) =
 
   override __.IsRelocatable = false
 
+  override __.BaseAddress = baseAddr
+
   override __.EntryPoint = Some baseAddr
 
   override __.TextStartAddr = baseAddr


### PR DESCRIPTION
Please note that the BaseAddress field doesn't necessarily need to be the same in runtime, as there are other factors that affects the value of this field (e.g. Relocations).