### PR TITLE
[Core] Replace ArchToString function keyword with direct pattern matc…

### DIFF
--- a/src/Core/ISA.fs
+++ b/src/Core/ISA.fs
@@ -157,7 +157,8 @@ with
     | "tms320c6000" -> ISA.Init (Arch.TMS320C6000) Endian.Little
     | _ -> raise InvalidISAException
 
-  static member ArchToString = function
+  static member ArchToString arch =
+    match arch with
     | Arch.IntelX86 -> "x86"
     | Arch.IntelX64 -> "x86-64"
     | Arch.ARMv7 -> "ARMv7"


### PR DESCRIPTION
Using `function keyword` makes the compiler generate a `Microsoft.FSharp.Core.FSharpFunc` which is a bit annoying, Instead replacing the `function keyword` with regular `pattern matching` generates a pure function, so the consumer's code base becomes more clean and straightforward.