### PR TITLE
[Visualization] Fix operator precedence

### DIFF
--- a/src/RearEnd/Visualization/CoordAssignment.fs
+++ b/src/RearEnd/Visualization/CoordAssignment.fs
@@ -275,7 +275,7 @@ let averageMedian (xAlignments: FloatMap list) =
   let xs = Map.fold (fun xs _ x -> x :: xs) [] medians
   let minX = List.min xs
   let maxX = List.max xs
-  let mid = minX + maxX / 2.0
+  let mid = (minX + maxX) / 2.0
   let medians = Map.map (fun _ xs -> xs - mid) medians
   Map.iter setXPos medians
 


### PR DESCRIPTION
Close #311 

This PR fixes operator precedence issues in coordinate calculations (average median logic).

Although the expressions were ambiguous and potentially misleading, the practical impact on the layout was minimal. Since the coordinate computation still maintained relative positioning, the overall layout was not significantly affected or broken.

The change mainly improves correctness, clarity, and mathematical intent of the implementation rather than altering the layout behavior in a noticeable way.