### PR TITLE
[Intel] Initialize temp value in crc32's bitReflect

### DIFF
--- a/src/FrontEnd/Intel/GeneralLifter.fs
+++ b/src/FrontEnd/Intel/GeneralLifter.fs
@@ -1033,6 +1033,7 @@ let convWDQ ins insLen bld =
 let private bitReflect bld src =
   let oprSize = Expr.TypeOf src
   let struct (res, tmp) = tmpVars2 bld oprSize
+  bld <+ (res := AST.num0 oprSize)
   bld <+ (tmp := src)
   let oSz = int oprSize
   for i in 0 .. oSz - 1 do


### PR DESCRIPTION
In crc32's `bitReflect` helper function, `res` is used before being assigned:

In dumped IR we can see: `TempVar (8, 9, null)` gets used in its first assignment.

The fix, initialize `res` to 0.

```
[|ISMark (5u, null);
  Put
    (TempVar (8, 1, null), Extract (Var (64, 3, "RBX", null), 8, 0, null), null);
  Put (TempVar (64, 2, null), Num (0x11edc6f41:I64, null), null);
  Put (TempVar (8, 10, null), TempVar (8, 1, null), null);
  Put
    (TempVar (8, 9, null),
     BinOp
       (OR, 8, BinOp (AND, 8, TempVar (8, 9, null), Num (0x7f:I8, null), null),
        BinOp
          (SHL, 8,
           Cast (ZeroExt, 8, Extract (TempVar (8, 10, null), 1, 0, null), null),
           Num (0x7:I8, null), null), null), null);
```

Fixes #338 