### PR TITLE
Fix inconsistent SSA lifter root selection between DEBUG and RELEASE

### DIFF
--- a/src/MiddleEnd/SSA/SSALifterFactory.fs
+++ b/src/MiddleEnd/SSA/SSALifterFactory.fs
@@ -106,11 +106,7 @@ module private SSALifterFactory =
 
   let convertToSSA stmtProcessor (cfg: LowUIRCFG) (ssaCFG: SSACFG) =
     let vMap = SSAVMap()
-#if DEBUG
     getVertex stmtProcessor vMap ssaCFG cfg.SingleRoot |> ignore
-#else
-    getVertex stmtProcessor vMap ssaCFG cfg.Roots[0] |> ignore
-#endif
     cfg |> DiGraph.iterEdge (fun e ->
       let src, dst = e.First, e.Second
       let srcV = getVertex stmtProcessor vMap ssaCFG src
@@ -317,11 +313,7 @@ module private SSALifterFactory =
     for variable in (defSites: DefSites).Keys do
       count[variable] <- 0
       stack[variable] <- [0]
-#if DEBUG
     rename g domTree count stack g.SingleRoot
-#else
-    rename g domTree count stack (g.Roots[0])
-#endif
 
   /// Add phis and rename all the variables in the SSACFG.
   let updatePhis ssaCFG dom =


### PR DESCRIPTION
Fixes #465.

**Root cause:** `SSALifterFactory.convertToSSA()` and `renameVars()` each picked the SSA lifting entry point differently depending on build configuration -- `cfg.SingleRoot` in DEBUG, `cfg.Roots[0]` in RELEASE. `SingleRoot` validates that the CFG has exactly one root and throws (`NoRootVertexException` / `MultipleRootVerticesException`) otherwise; `Roots[0]` just takes the first array element unconditionally, with no validation.

For a CFG with more than one root, this means DEBUG builds fail loudly during development, while RELEASE builds silently proceed using only the first root -- any block only reachable from a second (or later) root is dropped from the resulting SSA graph with no error or warning, producing a wrong analysis result instead of a failure a user could actually notice.

**Fix:** removed both `#if DEBUG/#else/#endif` blocks in favor of calling `SingleRoot` unconditionally in both branches, per the issue's suggestion to lean on the existing root-marking API instead of compilation-mode-dependent behavior. `SingleRoot`'s check is O(1) (`Roots.Count`), so there's no performance reason for the RELEASE shortcut -- this makes RELEASE match DEBUG's already-tested, validated behavior rather than the other way around.

`grep -rn "Roots\[0\]"` across `src/` confirms these were the only two call sites in the codebase, matching exactly what the issue names -- the fix doesn't touch anything beyond the two spots reported.

**Verification:**
- Built `src/MiddleEnd/SSA/B2R2.MiddleEnd.SSA.fsproj` clean in both Debug and Release (net10.0, 0 warnings/errors each).
- Ran the two existing test suites that exercise this code path end-to-end on real binaries/CFGs, in Release configuration: `B2R2.MiddleEnd.API.Tests` (31/31 passed) and `B2R2.MiddleEnd.DataFlow.Tests` (7/7 passed) -- no regression on the common single-root case, which is what these tests cover.
- Confirmed the DEBUG/RELEASE divergence conceptually with a standalone F# reproduction mirroring `SingleRoot`/`Roots[0]`'s exact semantics against a constructed 2-root graph: the old RELEASE path silently returns the wrong root with no error, the fixed path raises the same `MultipleRootVerticesException` DEBUG already did.

I used AI assistance for this, but not entirely.