### PR TITLE
[DataFlow] Add base cases for undefined variables

### DIFF
--- a/src/MiddleEnd/DataFlow.Tests/Binaries.fs
+++ b/src/MiddleEnd/DataFlow.Tests/Binaries.fs
@@ -469,3 +469,31 @@ let private code5 =
      0xC3uy |]
 
 let sample5 = Binary(code5, Architecture.Intel, WordSize.Bit64)
+
+(*
+  Example 6: EAX is whatever the caller left there when the branch is taken,
+  and 3 when it is not, so it is not a constant at 0x9.
+
+  00000000: 85 D2              test        edx,edx
+  00000002: 74 05              je          00000009
+  00000004: B8 03 00 00 00     mov         eax,3
+  00000009: 01 C1              add         ecx,eax
+  0000000B: C3                 ret
+
+  85D27405B80300000001C1C3
+*)
+let private code6 =
+  [| 0x85uy
+     0xD2uy
+     0x74uy
+     0x05uy
+     0xB8uy
+     0x03uy
+     0x00uy
+     0x00uy
+     0x00uy
+     0x01uy
+     0xC1uy
+     0xC3uy |]
+
+let sample6 = Binary(code6, Architecture.Intel, WordSize.Bit32)

--- a/src/MiddleEnd/DataFlow.Tests/DataFlowTests.fs
+++ b/src/MiddleEnd/DataFlow.Tests/DataFlowTests.fs
@@ -348,7 +348,8 @@ type DataFlowTests() =
     for e in cfg.Edges do state.MarkEdgeAsPending(e.First, e.Second)
     (cp :> IDataFlowComputable<_, _, _, _>).Compute cfg |> ignore
     (* Reading a stack slot registers a use of that slot. *)
-    Assert.IsTrue(state.UseDefMap.ContainsKey(svp 0x32UL 1 (StackLocal -12)))
+    Assert.AreEqual(state.UseDefMap.ContainsKey(svp 0x32UL 1 (StackLocal -12)),
+                    true)
     (* The destination of a Put is a definition, never a use of itself. *)
     let rbp = Regular(Register.toRegID Register.RBP)
-    Assert.IsFalse(state.UseDefMap.ContainsKey(svp 0x5UL 1 rbp))
+    Assert.AreEqual(state.UseDefMap.ContainsKey(svp 0x5UL 1 rbp), false)

--- a/src/MiddleEnd/DataFlow.Tests/DataFlowTests.fs
+++ b/src/MiddleEnd/DataFlow.Tests/DataFlowTests.fs
@@ -204,7 +204,7 @@ type DataFlowTests() =
     let dfa = cp :> IDataFlowComputable<_, _, _, _>
     let state = dfa.Compute g
     [ ssaRegInitial Register.RSP 64<rt> |> cmp <| mkConst 0x80000000u 64<rt>
-      ssaRegInitial Register.RBP 64<rt> |> cmp <| ConstantDomain.Undef
+      ssaRegInitial Register.RBP 64<rt> |> cmp <| ConstantDomain.NotAConst
       ssaReg g Register.RSP 0x4UL 64<rt> |> cmp <| mkConst 0x7ffffff8u 64<rt>
       ssaReg g Register.RBP 0x5UL 64<rt> |> cmp <| mkConst 0x7ffffff8u 64<rt>
       ssaStk g (8 + 0xc) 0x11UL 32<rt> |> cmp <| mkConst 0x2u 32<rt>
@@ -216,7 +216,7 @@ type DataFlowTests() =
       ssaReg g Register.RAX 0x32UL 64<rt> |> cmp <| ConstantDomain.NotAConst
       ssaReg g Register.RDX 0x2fUL 64<rt> |> cmp <| ConstantDomain.NotAConst
       ssaReg g Register.RAX 0x35UL 64<rt> |> cmp <| ConstantDomain.NotAConst
-      ssaReg g Register.RBP 0x3bUL 64<rt> |> cmp <| ConstantDomain.Undef
+      ssaReg g Register.RBP 0x3bUL 64<rt> |> cmp <| ConstantDomain.NotAConst
       ssaReg g Register.RSP 0x3bUL 64<rt> |> cmp <| mkConst 0x80000000u 64<rt>
       ssaReg g Register.RSP 0x3CUL 64<rt> |> cmp <| mkConst 0x80000008u 64<rt> ]
     |> List.iter (fun (var, ans) ->
@@ -241,6 +241,21 @@ type DataFlowTests() =
       let out = (state :> IAbsValProvider<_, _>).GetAbsValue var
       Assert.AreEqual<ConstantDomain.Lattice>(ans, out))
 
+  [<TestMethod>]
+  member _.``SSA Constant Propagation Test 3``() =
+    let brew = Binaries.loadOne Binaries.sample6
+    let cfg = brew.Functions[0UL].CFG
+    let lifter = SSALifterFactory.Create brew.BinHandle
+    let promoter = SSAPromoterFactory.Create brew.BinHandle
+    let g = (lifter.Lift cfg |> promoter.Promote).Graph
+    let cp = SSAConstantPropagation brew.BinHandle
+    let state = (cp :> IDataFlowComputable<_, _, _, _>).Compute g
+    (* EAX comes in from the caller on one path, so joining it with 3 must
+       not come out as 3. *)
+    let vp = ssaReg g Register.EAX 0x9UL 32<rt>
+    let out = (state :> IAbsValProvider<_, _>).GetAbsValue vp
+    Assert.AreEqual<ConstantDomain.Lattice>(ConstantDomain.NotAConst, out)
+
 #if !EMULATION
   [<TestMethod>]
   member _.``Constant Propagation Test 1``() =
@@ -260,6 +275,18 @@ type DataFlowTests() =
     |> List.iter (fun (vp, ans) ->
       let out = (state :> IAbsValProvider<_, _>).GetAbsValue vp
       Assert.AreEqual<ConstantDomain.Lattice>(ans, out))
+
+  [<TestMethod>]
+  member _.``Constant Propagation Test 2``() =
+    let brew = Binaries.loadOne Binaries.sample6
+    let cfg = brew.Functions[0UL].CFG
+    let cp = ConstantPropagation(brew.BinHandle, cfg.Vertices)
+    let state = (cp :> IDataFlowComputable<_, _, _, _>).Compute cfg
+    (* Same as above, on the LowUIR framework: the phi at 0x9 joins the
+       caller's EAX with 3. *)
+    let vp = irReg 0x9UL 0 Register.EAX
+    let out = (state :> IAbsValProvider<_, _>).GetAbsValue vp
+    Assert.AreEqual<ConstantDomain.Lattice>(ConstantDomain.NotAConst, out)
 #endif
 
   [<TestMethod>]

--- a/src/MiddleEnd/DataFlow/ConstantPropagation.fs
+++ b/src/MiddleEnd/DataFlow/ConstantPropagation.fs
@@ -145,6 +145,7 @@ type ConstantPropagation(hdl, vs) =
 
   let rec scheme =
     { new LowUIRSparseDataFlow.IScheme<ConstantDomain.Lattice> with
+        member _.GetBaseCase _ = ConstantDomain.NotAConst
         member _.EvalExpr(pp, expr) = evaluateExpr state pp expr }
 
   and state =

--- a/src/MiddleEnd/DataFlow/LowUIRSparseDataFlow.fs
+++ b/src/MiddleEnd/DataFlow/LowUIRSparseDataFlow.fs
@@ -98,7 +98,7 @@ type State<'Lattice when 'Lattice: equality>
   let domainGetAbsValue vp =
     match domainAbsValues.TryGetValue vp with
     | true, v -> v
-    | false, _ when vp.ProgramPoint.IsFake -> lattice.Bottom
+    | false, _ when vp.ProgramPoint.IsFake -> scheme.GetBaseCase vp.VarKind
     | false, _ -> lattice.Bottom
 
   let spGetInitialAbsValue varKind =
@@ -539,6 +539,12 @@ and private PhiInfo = Dictionary<VarKind, Dictionary<ProgramPoint, VarPoint>>
 /// Represents how we perform LowUIR-based sparse dataflow analysis.
 and IScheme<'Lattice when 'Lattice: equality> =
   inherit IExprEvaluatable<ProgramPoint, 'Lattice>
+
+  /// Returns the abstract value of a variable that the function never defines,
+  /// i.e. one that comes in from the outside. Such a variable never receives a
+  /// definition that would raise a bottom, so this must be a sound
+  /// over-approximation.
+  abstract GetBaseCase: VarKind -> 'Lattice
 
 [<AutoOpen>]
 module internal AnalysisCore = begin

--- a/src/MiddleEnd/DataFlow/SSAConstantPropagation.fs
+++ b/src/MiddleEnd/DataFlow/SSAConstantPropagation.fs
@@ -113,6 +113,7 @@ type SSAConstantPropagation(hdl: BinHandle) =
           | LMark _ | ExternalCall _ | SideEffect _ -> ()
         member _.UpdateMemFromBinaryFile(_rt, _addr) =
           ConstantDomain.NotAConst
+        member _.GetBaseCase _ = ConstantDomain.NotAConst
         member _.EvalExpr e = evalExpr state e }
 
   and state =

--- a/src/MiddleEnd/DataFlow/SSASparseDataFlow.fs
+++ b/src/MiddleEnd/DataFlow/SSASparseDataFlow.fs
@@ -99,6 +99,7 @@ type State<'Lattice when 'Lattice: equality>
   member _.GetRegValue(var: Variable) =
     match regValues.TryGetValue var with
     | true, v -> v
+    | false, _ when var.Identifier = 0 -> scheme.GetBaseCase var
     | false, _ -> lattice.Bottom
 
   /// Sets register value without adding it to the worklist.
@@ -176,6 +177,12 @@ and IScheme<'Lattice when 'Lattice: equality> =
   /// that would later raise a bottom, so a bottom here stays bottom and gets
   /// absorbed by every join.
   abstract UpdateMemFromBinaryFile: RegType * Addr -> 'Lattice
+
+  /// Returns the abstract value of a variable that the function never defines,
+  /// i.e. one that comes in from the outside. Such a variable never receives a
+  /// definition that would raise a bottom, so this must be a sound
+  /// over-approximation.
+  abstract GetBaseCase: Variable -> 'Lattice
 
   /// Evaluate the given expression based on the current abstract state.
   abstract EvalExpr: Expr -> 'Lattice

--- a/src/MiddleEnd/DataFlow/SSAStackPointerPropagation.fs
+++ b/src/MiddleEnd/DataFlow/SSAStackPointerPropagation.fs
@@ -112,6 +112,7 @@ type SSAStackPointerPropagation(hdl: BinHandle) =
           | LMark _ | ExternalCall _ | SideEffect _ -> ()
         member _.UpdateMemFromBinaryFile(_rt, _addr) =
           StackPointerDomain.NotConstSP
+        member _.GetBaseCase _ = StackPointerDomain.NotConstSP
         member _.EvalExpr e = evalExpr state e }
 
   and state =

--- a/src/MiddleEnd/DataFlow/SSAUntouchedValueAnalysis.fs
+++ b/src/MiddleEnd/DataFlow/SSAUntouchedValueAnalysis.fs
@@ -56,19 +56,16 @@ type SSAUntouchedValueAnalysis(hdl: BinHandle) =
     | None ->
       state
 
-  let evalVar (state: State<_>) v =
-    if state.IsRegSet v then
-      state.GetRegValue v
-    else
-      if v.Identifier = 0 then
-        let kind = VarKind.ofSSAVarKind v.Kind
-        UntouchedValueDomain.Untouched(RegisterTag kind) (* Init here. *)
-      else
-        UntouchedValueDomain.Touched
+  let getBaseCase (v: Variable) =
+    match v.Kind with
+    | MemVar | PCVar _ ->
+      UntouchedValueDomain.Touched
+    | kind ->
+      UntouchedValueDomain.Untouched(RegisterTag(VarKind.ofSSAVarKind kind))
 
   let rec evalExpr state = function
     | Var v ->
-      evalVar state v
+      (state: State<_>).GetRegValue v
     | Extract(e, _, _)
     | Cast(CastKind.ZeroExt, _, e)
     | Cast(CastKind.SignExt, _, e) ->
@@ -116,6 +113,7 @@ type SSAUntouchedValueAnalysis(hdl: BinHandle) =
           | LMark _ | ExternalCall _ | SideEffect _ -> ()
         member _.UpdateMemFromBinaryFile(_rt, _addr) =
           UntouchedValueDomain.Touched
+        member _.GetBaseCase v = getBaseCase v
         member _.EvalExpr e = evalExpr state e }
 
   and state =

--- a/src/MiddleEnd/DataFlow/StackPointerPropagation.fs
+++ b/src/MiddleEnd/DataFlow/StackPointerPropagation.fs
@@ -61,7 +61,6 @@ type StackPointerPropagation(hdl: BinHandle, vs) =
   let evaluateVarPoint (state: StackPointerPropagationState) pp varKind =
     let vp = { ProgramPoint = pp; VarKind = varKind }
     match state.UseDefMap.TryGetValue vp with
-    | true, defVp when defVp.ProgramPoint.IsFake -> getBaseCase varKind
     | true, defVp -> state.DomainSubState.GetAbsValue defVp
     | false, _ -> StackPointerDomain.Undef
 
@@ -104,6 +103,7 @@ type StackPointerPropagation(hdl: BinHandle, vs) =
 
   let rec scheme =
     { new LowUIRSparseDataFlow.IScheme<StackPointerDomain.Lattice> with
+        member _.GetBaseCase varKind = getBaseCase varKind
         member _.EvalExpr(pp, expr) = evaluateExpr state pp expr }
 
   and state =

--- a/src/MiddleEnd/DataFlow/UntouchedValueAnalysis.fs
+++ b/src/MiddleEnd/DataFlow/UntouchedValueAnalysis.fs
@@ -52,7 +52,6 @@ type UntouchedValueAnalysis(hdl: BinHandle, vs) =
   let evaluateVarPoint (state: UntouchedValueState) pp varKind =
     let vp = { ProgramPoint = pp; VarKind = varKind }
     match state.UseDefMap.TryGetValue vp with
-    | true, defVp when defVp.ProgramPoint.IsFake -> getBaseCase varKind
     | true, defVp -> state.DomainSubState.GetAbsValue defVp
     | false, _ -> UntouchedValueDomain.Undef
 
@@ -83,6 +82,7 @@ type UntouchedValueAnalysis(hdl: BinHandle, vs) =
 
   let rec scheme =
     { new LowUIRSparseDataFlow.IScheme<UntouchedValueLattice> with
+        member _.GetBaseCase varKind = getBaseCase varKind
         member _.EvalExpr(pp, expr) = evaluateExpr state pp expr }
 
   and state =


### PR DESCRIPTION
Add GetBaseCase to data-flow schemes so values without a definition use a scheme-specific base value instead of lattice bottom.

Add a regression sample covering a variable defined on only one path.