### PR TITLE
[DataFlow] Fix bugs in LowUIRSensitiveDataFlow

### DIFF
--- a/src/MiddleEnd/DataFlow.Tests/DataFlowTests.fs
+++ b/src/MiddleEnd/DataFlow.Tests/DataFlowTests.fs
@@ -104,10 +104,11 @@ type DataFlowTests() =
     let varKind = StackLocal offset
     { ProgramPoint = pp; VarKind = varKind }
 
+  let spp addr idx: SensitiveProgramPoint<int> =
+    { ProgramPoint = ProgramPoint(addr, idx); ExecutionContext = 0 }
+
   let svp addr idx varKind: SensitiveVarPoint<int> =
-    let spp: SensitiveProgramPoint<int> =
-      { ProgramPoint = ProgramPoint(addr, idx); ExecutionContext = 0 }
-    { SensitiveProgramPoint = spp; VarKind = varKind }
+    { SensitiveProgramPoint = spp addr idx; VarKind = varKind }
 
   let mkUntouchedReg r =
     Regular(Register.toRegID r)
@@ -353,3 +354,24 @@ type DataFlowTests() =
     (* The destination of a Put is a definition, never a use of itself. *)
     let rbp = Regular(Register.toRegID Register.RBP)
     Assert.AreEqual(state.UseDefMap.ContainsKey(svp 0x5UL 1 rbp), false)
+
+  [<TestMethod>]
+  member _.``Sensitive Constant Propagation Test 1``() =
+    let brew = Binaries.loadOne Binaries.sample6
+    let cfg = brew.Functions[0UL].CFG
+    let scheme =
+      { new LowUIRSensitiveDataFlow.IScheme<ConstantDomain.Lattice, int> with
+          member _.DefaultExecutionContext = 0
+          member _.TryComputeExecutionContext(_, exeCtx, _, _) = Some exeCtx
+          member _.OnVertexNewlyAnalyzed _ = ()
+          member _.OnRemoveVertex _ = () }
+    let cp = LowUIRSensitiveConstantPropagation(brew.BinHandle, scheme)
+    let state = cp.State
+    for root in cfg.Roots do state.MarkEdgeAsPending(null, root)
+    for e in cfg.Edges do state.MarkEdgeAsPending(e.First, e.Second)
+    (cp :> IDataFlowComputable<_, _, _, _>).Compute cfg |> ignore
+    (* The path that skips 0x4 brings in the caller's EAX, so the read at 0x9
+       must not see 3. *)
+    let eax = brew.BinHandle.RegisterFactory.GetRegVar "EAX"
+    let out = cp.EvalExpr(spp 0x9UL 2, eax)
+    Assert.AreEqual<ConstantDomain.Lattice>(ConstantDomain.NotAConst, out)

--- a/src/MiddleEnd/DataFlow/LowUIRSensitiveConstantPropagation.fs
+++ b/src/MiddleEnd/DataFlow/LowUIRSensitiveConstantPropagation.fs
@@ -36,6 +36,14 @@ open B2R2.MiddleEnd.DataFlow.LowUIRSensitiveDataFlow
 type LowUIRSensitiveConstantPropagation<'ExeCtx when 'ExeCtx: comparison>
   public(hdl: BinHandle, scheme: IScheme<ConstantDomain.Lattice, 'ExeCtx>) =
 
+  /// A definition coming in from outside the function is unknown, so it must
+  /// not be answered with the lattice bottom, which every join would absorb.
+  let evaluateDef (state: State<_, _>) (defSvp: SensitiveVarPoint<_>) =
+    if defSvp.SensitiveProgramPoint.ProgramPoint.IsFake then
+      ConstantDomain.NotAConst
+    else
+      (state :> IAbsValProvider<_, _>).GetAbsValue defSvp
+
   let evaluateVarPoint (state: State<_, _>) spp varKind =
     let svp = { SensitiveProgramPoint = spp; VarKind = varKind }
     match state.UseDefMap.TryGetValue svp with
@@ -44,7 +52,7 @@ type LowUIRSensitiveConstantPropagation<'ExeCtx when 'ExeCtx: comparison>
     | true, rds ->
       rds
       |> Seq.fold (fun acc defSvp ->
-        (state: IAbsValProvider<_, _>).GetAbsValue defSvp
+        evaluateDef state defSvp
         |> ConstantDomain.join acc) ConstantDomain.Undef
 
   let rec evaluateExpr state spp e =

--- a/src/MiddleEnd/DataFlow/LowUIRSensitiveDataFlow.fs
+++ b/src/MiddleEnd/DataFlow/LowUIRSensitiveDataFlow.fs
@@ -791,7 +791,15 @@ module internal AnalysisCore = begin
     | StackPointerDomain.ConstSP bv -> bv.ToUInt64() |> toFrameOffset
     | _ -> Terminator.impossible ()
 
-  /// Join the two reaching definition maps. We filter out temporary variables
+  /// Returns true if the given variable kind does not survive a join into a
+  /// vertex whose incoming stack pointer sits at the given frame offset.
+  let isPrunedVarKind dstInStackOff vk =
+    match vk with
+    | Temporary _ -> true
+    | StackLocal offset when offset < dstInStackOff -> true
+    | _ -> false
+
+  /// Joins the two reaching definition maps. We filter out temporary variables
   /// here.
   /// TODO: check if it is propagated through intra-block edges like
   /// `VarBasedDataFlowAnalysis`.
@@ -799,12 +807,7 @@ module internal AnalysisCore = begin
                        (m2: SensitiveReachingDefs<_>) =
     let dstInStackOff = stackPointerToFrameOffset dstInSP
     m1 |> Map.fold (fun (changed, acc) vk defs ->
-      let shouldBePruned =
-        match vk with
-        | Temporary _ -> true
-        | StackLocal offset when offset < dstInStackOff -> true
-        | _ -> false
-      if shouldBePruned then
+      if isPrunedVarKind dstInStackOff vk then
         changed, acc
       else
         match Map.tryFind vk m2 with
@@ -895,7 +898,20 @@ module internal AnalysisCore = begin
         ()
     queue
 
-  let tryJoinRDs state src srcExeCtx dst dstExeCtx =
+  /// A variable that one side never defines still flows through that side,
+  /// carrying whatever value it held on function entry. `updateChains`
+  /// introduces a fake definition when a variable is absent from the map;
+  /// this function handles variables defined on one side but not the other
+  /// at a merge point.
+  let introduceFakeDefsAtMergePoint exeCtx dstInStackOff m1 m2 =
+    let introduceMissingFakeDefs other m =
+      (m, Map.keys other)
+      ||> Seq.fold (fun m vk ->
+        if Map.containsKey vk m || isPrunedVarKind dstInStackOff vk then m
+        else Map.add vk (Set.singleton (makeFakeDefSvp exeCtx vk)) m)
+    introduceMissingFakeDefs m2 m1, introduceMissingFakeDefs m1 m2
+
+  let tryJoinRDs (state: State<_, _>) src srcExeCtx dst dstExeCtx =
     let srcOutDefs = getOutgoingDefs state src srcExeCtx
     let dstInDefs = getIncomingDefs state dst dstExeCtx
     let dstInSP =
@@ -906,6 +922,12 @@ module internal AnalysisCore = begin
         |> StackPointerDomain.ConstSP
       else
         snd state.PerVertexStackPointerInfos[src, srcExeCtx]
+    let srcOutDefs, dstInDefs =
+      if state.PerVertexIncomingDefs.ContainsKey(dst, dstExeCtx) then
+        let off = stackPointerToFrameOffset dstInSP
+        introduceFakeDefsAtMergePoint dstExeCtx off srcOutDefs dstInDefs
+      else
+        srcOutDefs, dstInDefs
     match joinDefs dstInSP srcOutDefs dstInDefs with
     | true, dstInDefs' -> Some dstInDefs'
     (* This can happen when this was the first visit to the vertex. *)


### PR DESCRIPTION
- Evaluate fake variables to a lattice top.
- Introduce fake variables at merge points.